### PR TITLE
impl of automatic login function by cookie.

### DIFF
--- a/authlib/__init__.py
+++ b/authlib/__init__.py
@@ -1,4 +1,4 @@
 from .common import const, trace_activity, AppError, DatabaseError
 from .common.dt_helpers import tnow_iso , tnow_iso_str, dt_from_str, dt_from_ts, dt_to_str
 from .common.crypto import aes256cbcExtended
-from .common.cookie_manager import cookie_manager
+from .common.cookie_manager import CookieManager

--- a/authlib/__init__.py
+++ b/authlib/__init__.py
@@ -1,4 +1,4 @@
 from .common import const, trace_activity, AppError, DatabaseError
 from .common.dt_helpers import tnow_iso , tnow_iso_str, dt_from_str, dt_from_ts, dt_to_str
 from .common.crypto import aes256cbcExtended
-
+from .common.cookie_manager import cookie_manager

--- a/authlib/auth.py
+++ b/authlib/auth.py
@@ -6,7 +6,7 @@ import logging
 
 import streamlit as st
 
-from . import const, aes256cbcExtended, cookie_manager
+from . import const, aes256cbcExtended, CookieManager
 
 # ------------------------------------------------------------------------------
 # Globals
@@ -16,7 +16,7 @@ ENC_NONCE = osenv.get('ENC_NONCE')
 STORAGE = osenv.get('STORAGE', 'SQLITE')
 COOKIE_NAME = osenv.get('COOKIE_NAME')
 store = None
-
+cookie_manager = CookieManager()
 # ------------------------------------------------------------------------------
 
 # Wrapping session state in a function ensures that 'user' (or any attribute really) is
@@ -57,7 +57,7 @@ def requires_auth(fn):
 @requires_auth
 def logout():
     auth_state().user = None
-    cookie_manager().delete(COOKIE_NAME)
+    cookie_manager.delete(COOKIE_NAME)
 
 def authenticated():
     return auth_state().user != None
@@ -98,8 +98,8 @@ def _auth(sidebar=True, show_msgs=True):
     if auth_state().user == None:
 
         # cookie login
-        cookie_manager().get_all()
-        user_in_cookie = cookie_manager().get(cookie=COOKIE_NAME)
+        cookie_manager.get_all()
+        user_in_cookie = cookie_manager.get(cookie=COOKIE_NAME)
         if user_in_cookie:
             ctx={'fields': "*", 'conds': f"username=\"{user_in_cookie[const.USERNAME]}\""}
             data = store.query(context=ctx)
@@ -136,12 +136,12 @@ def _auth(sidebar=True, show_msgs=True):
         if auth_state().user[const.SU] == 1:
             if su_widget(f"Super users can edit user DB"):
                 _superuser_mode()
-        if cookie_manager().get(cookie=COOKIE_NAME):
+        if cookie_manager.get(cookie=COOKIE_NAME):
             if not remember_me_widget("Remember me", value=True):
-                cookie_manager().delete(COOKIE_NAME)
+                cookie_manager.delete(COOKIE_NAME)
         else:
             if remember_me_widget("Remember me", value=False):
-                cookie_manager().set(COOKIE_NAME, auth_state().user)
+                cookie_manager.set(COOKIE_NAME, auth_state().user)
 
     return auth_state().user[const.USERNAME] if auth_state().user != None else None
 

--- a/authlib/auth.py
+++ b/authlib/auth.py
@@ -5,6 +5,7 @@ from functools import wraps
 import logging
 
 import streamlit as st
+import extra_streamlit_components as stx
 
 from . import const, aes256cbcExtended
 
@@ -14,9 +15,14 @@ ENC_PASSWORD = osenv.get('ENC_PASSWORD')
 ENC_NONCE = osenv.get('ENC_NONCE')
 
 STORAGE = osenv.get('STORAGE', 'SQLITE')
+COOKIE_NAME = osenv.get('COOKIE_NAME')
 store = None
 
 # ------------------------------------------------------------------------------
+
+@st.cache(allow_output_mutation=True)
+def get_manager():
+    return stx.CookieManager()
 
 # Wrapping session state in a function ensures that 'user' (or any attribute really) is
 # in the session state and, in my opinion, works better with Streamlit's execution model,
@@ -56,6 +62,7 @@ def requires_auth(fn):
 @requires_auth
 def logout():
     auth_state().user = None
+    get_manager().delete(COOKIE_NAME)
 
 def authenticated():
     return auth_state().user != None
@@ -87,12 +94,27 @@ def _auth(sidebar=True, show_msgs=True):
     header_widget = st.sidebar.subheader if sidebar else st.subheader
     username_widget = st.sidebar.text_input if sidebar else st.text_input
     password_widget = st.sidebar.text_input if sidebar else st.text_input
+    autologin_widget = st.sidebar.checkbox if sidebar else st.checkbox
     su_widget = st.sidebar.checkbox if sidebar else st.checkbox
     logout_widget = st.sidebar.button if sidebar else st.button
 
     header_widget('Authentication')
 
     if auth_state().user == None:
+
+        # cookie login
+        get_manager().get_all()
+        user_in_cookie = get_manager().get(cookie=COOKIE_NAME)
+        if user_in_cookie:
+            ctx={'fields': "*", 'conds': f"username=\"{user_in_cookie[const.USERNAME]}\""}
+            data = store.query(context=ctx)
+            user = data[0] if data else None
+            # After checking for the presence of a user name, encrypted passwords are compared with each other.
+            if user and user[const.PASSWORD] == user_in_cookie[const.PASSWORD]:
+                auth_state().user = user
+                set_auth_message('Logging in...', type=const.SUCCESS, show_msgs=show_msgs)
+                st.experimental_rerun()
+
         set_auth_message('Please log in', delay=None, show_msgs=True)
 
         username = username_widget("Enter username", value='')
@@ -119,6 +141,12 @@ def _auth(sidebar=True, show_msgs=True):
         if auth_state().user[const.SU] == 1:
             if su_widget(f"Super users can edit user DB"):
                 _superuser_mode()
+        if get_manager().get(cookie=COOKIE_NAME):
+            if not autologin_widget(f"Allow automatic login with cookies", value=True):
+                get_manager().delete(COOKIE_NAME)
+        else:
+            if autologin_widget(f"Allow automatic login with cookies", value=False):
+                get_manager().set(COOKIE_NAME, auth_state().user)
 
     return auth_state().user[const.USERNAME] if auth_state().user != None else None
 

--- a/authlib/common/cookie_manager.py
+++ b/authlib/common/cookie_manager.py
@@ -1,6 +1,26 @@
+import datetime
 import streamlit as st
 import extra_streamlit_components as stx
 
-@st.experimental_singleton
-def cookie_manager():
-    return stx.CookieManager()
+class CookieManager():
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    @st.experimental_singleton
+    def get_manager():
+        return stx.CookieManager()
+
+    def get(self, cookie: str):
+        return CookieManager.get_manager().get(cookie)
+
+    def set(self, cookie, val, expires_at=datetime.datetime.now() + datetime.timedelta(days=1),
+            key="set"):
+        return CookieManager.get_manager().set(cookie=cookie, val=val, expires_at=expires_at, key=key)
+
+    def delete(self, cookie, key="delete"):
+        return CookieManager.get_manager().delete(cookie=cookie, key=key)
+
+    def get_all(self, key="get_all"):
+        return CookieManager.get_manager().get_all()

--- a/authlib/common/cookie_manager.py
+++ b/authlib/common/cookie_manager.py
@@ -1,0 +1,6 @@
+import streamlit as st
+import extra_streamlit_components as stx
+
+@st.experimental_singleton
+def cookie_manager():
+    return stx.CookieManager()

--- a/env.sample
+++ b/env.sample
@@ -15,3 +15,6 @@ USERS_TABLE = 'users'
 # Encryption keys
 ENC_PASSWORD='YouWillNeverGuessThisSecretKey32'
 ENC_NONCE='nonsensical'
+
+# Cookie name
+COOKIE_NAME='auth-simple-for-streamlit'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyairtable==1.0.0rc3
-streamlit==0.86.0
+streamlit==0.89.0
 debugpy==1.3.0
 pycryptodome==3.10.1
 python-dotenv==0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ streamlit==0.86.0
 debugpy==1.3.0
 pycryptodome==3.10.1
 python-dotenv==0.19.0
+extra-streamlit-components==0.1.53

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyairtable==1.0.0rc3
-streamlit==0.89.0
+streamlit==1.7.0
 debugpy==1.3.0
 pycryptodome==3.10.1
 python-dotenv==0.19.0


### PR DESCRIPTION
## About
Since the existing login function logs you out when you reload your browser, we added an automatic login function using cookies.

## Details
- The cookie holds the user name and encrypted password. Should I set a default expiration date?
- If the access user has a cookie, verify the user's existence and match the password while it is still encrypted.
- Discard cookies when auto-login is checked off or logged out.

## Check
- [ ] After checking auto-login, the user must be able to auto-login with a browser that retains the cookie.(reload or something).
- [ ] Unable to auto-login from a browser that has retained the cookie after unchecking auto-login. (Like reloading)

## etc
To avoid complicating the DB functionality, I implemented the idea that the management of authentication status could be left to the cookie expiration date. What do you think?